### PR TITLE
Simmer Down, Wave!

### DIFF
--- a/src/Wave.Core/Filters/ThrottleMessages.cs
+++ b/src/Wave.Core/Filters/ThrottleMessages.cs
@@ -73,7 +73,7 @@ namespace Wave.Filters
             }
             else
             {
-                this.log.Value.InfoFormat("Delivery rate limit exceeded - Redelivering message {0} in {1}ms", message.ToString(), this.delayInterval.TotalMilliseconds);
+                this.log.Value.DebugFormat("Delivery rate limit exceeded - Redelivering message {0} in {1}ms", message.ToString(), this.delayInterval.TotalMilliseconds);
                 return this.Delay(this.delayInterval);
             }
         }

--- a/src/Wave.Core/HandlerResults/RetryResult.cs
+++ b/src/Wave.Core/HandlerResults/RetryResult.cs
@@ -27,9 +27,14 @@ namespace Wave.HandlerResults
 
         public string Message { get; private set; }
 
+        public static bool ShouldRetry(RawMessage message)
+        {
+            return message.RetryCount < ConfigurationContext.Current.MessageRetryLimit;
+        }
+
         public void ProcessResult(RawMessage message, ITransport transport, ILogger log)
         {
-            if (message.RetryCount < ConfigurationContext.Current.MessageRetryLimit)
+            if (ShouldRetry(message))
             {
                 message.RetryCount++;
                 log.InfoFormat("Message requested to be retried {0} - Retry Count {1}", message.ToString(), message.RetryCount);


### PR DESCRIPTION
A couple goals here:  reduce potential log volume in a high-volume throttling scenario, and downgrade retriable exceptions to warnings to allow us to focus attention on the non-transient errors.  Warnings can still be analyzed to track transient issues.

![image](https://cloud.githubusercontent.com/assets/6437309/13432517/d46cff2a-df82-11e5-95e9-f93547624b95.png)
